### PR TITLE
Replaced some compile dependencies with compileOnly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ ext {
     spekVersion = '1.1.2'
 
     // Core libs
+    supportCoreUi = "com.android.support:support-core-ui:$androidSupportVersion"
     supportAppCompat = "com.android.support:appcompat-v7:$androidSupportVersion"
     supportDesign = "com.android.support:design:$androidSupportVersion"
     kotlinStdLib = "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ ext {
     kotlinStdLib = "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     kotlinTest = "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     ankoCommons = "org.jetbrains.anko:anko-commons:$ankoVersion"
+    ankoSdk15 = "org.jetbrains.anko:anko-sdk15:$ankoVersion"
     ankoSdk21 = "org.jetbrains.anko:anko-sdk21:$ankoVersion"
     ankoAppCompat = "org.jetbrains.anko:anko-appcompat-v7:$ankoVersion"
     ankoDesign = "org.jetbrains.anko:anko-design:$ankoVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
     // DI libs
     dagger = "com.google.dagger:dagger:$daggerVersion"
     daggerCompiler = "com.google.dagger:dagger-compiler:$daggerVersion"
-    javaxAnnotation = 'javax.annotation:jsr250-api:1.0'
+    javaxInject = 'javax.inject:javax.inject:1@jar'
     // Rx libs
     rxJava = 'io.reactivex.rxjava2:rxjava:2.0.9'
     rxAndroid = 'io.reactivex.rxjava2:rxandroid:2.0.1'

--- a/screens/build.gradle
+++ b/screens/build.gradle
@@ -19,12 +19,13 @@ android {
 }
 
 dependencies {
-    provided supportCoreUi // Compile only dependency for *optional* PagerAdapter support.
+    // Optional compile only dependencies
+    provided supportCoreUi
+    provided ankoCommons
+    provided ankoSdk15
 
     // Core libs
     compile kotlinStdLib
-    compile ankoCommons
-    compile ankoSdk21
     // DI libs
     compile javaxInject
     // Rx libs

--- a/screens/build.gradle
+++ b/screens/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compile ankoCommons
     compile ankoSdk21
     // DI libs
-    compile dagger
+    compile javaxInject
     // Rx libs
     compile rxJava
     compile rxAndroid

--- a/screens/build.gradle
+++ b/screens/build.gradle
@@ -19,8 +19,9 @@ android {
 }
 
 dependencies {
+    provided supportCoreUi // Compile only dependency for *optional* PagerAdapter support.
+
     // Core libs
-    compile supportAppCompat
     compile kotlinStdLib
     compile ankoCommons
     compile ankoSdk21

--- a/screens/src/main/kotlin/com/cleverlance/mobile/android/screens/presenter/BaseInflaterScreenView.kt
+++ b/screens/src/main/kotlin/com/cleverlance/mobile/android/screens/presenter/BaseInflaterScreenView.kt
@@ -1,8 +1,9 @@
 package com.cleverlance.mobile.android.screens.presenter
 
+import android.content.Context
+import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import org.jetbrains.anko.layoutInflater
 
 abstract class BaseInflaterScreenView : BasePresenterView() {
     abstract val viewLayoutResource: Int
@@ -11,4 +12,7 @@ abstract class BaseInflaterScreenView : BasePresenterView() {
         rootView = container.context.layoutInflater.inflate(viewLayoutResource, container, false)
         return rootView
     }
+
+    private val Context.layoutInflater: LayoutInflater
+        get() = getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
 }


### PR DESCRIPTION
AppCompat:
AppCompat dependency was unused. It has been replaced by a compileOnly/non-transitive dependency on support-core-ui in order to work with PagerAdapter.

Anko:
Anko is now compileOnly dependency. This will allow the consumer easier control over which anko-sdkX to use.

Dagger:
Dagger is not used within the library and has been replaced by the inject-javax annotation.